### PR TITLE
feat: add 3d dice flutter web skeleton

### DIFF
--- a/lib/core/di/locator.dart
+++ b/lib/core/di/locator.dart
@@ -1,0 +1,9 @@
+import '../../domain/services/physics_service.dart';
+import '../../domain/services/render_service.dart';
+import '../../data/physics/physics_cannon_dart.dart';
+import '../../data/render/three_render_service.dart';
+
+class Locator {
+  static PhysicsService physics() => CannonDartPhysicsService();
+  static RenderService render() => ThreeRenderService();
+}

--- a/lib/core/utils/fps_counter.dart
+++ b/lib/core/utils/fps_counter.dart
@@ -1,0 +1,14 @@
+class FpsCounter {
+  int _frames = 0;
+  double _accum = 0;
+  double fps = 0;
+  void tick(double dt) {
+    _frames++;
+    _accum += dt;
+    if (_accum >= 1.0) {
+      fps = _frames / _accum;
+      _frames = 0;
+      _accum = 0;
+    }
+  }
+}

--- a/lib/core/utils/random_utils.dart
+++ b/lib/core/utils/random_utils.dart
@@ -1,0 +1,15 @@
+import 'dart:math';
+import 'package:vector_math/vector_math_64.dart';
+final _rnd = Random();
+
+double rnd(double min, double max) => min + _rnd.nextDouble() * (max - min);
+
+Vector3 rndVec(double s) => Vector3(rnd(-s, s), rnd(-s, s), rnd(-s, s));
+
+Quaternion rndQuat() {
+  final u1 = _rnd.nextDouble();
+  final u2 = _rnd.nextDouble() * 2 * pi;
+  final u3 = _rnd.nextDouble() * 2 * pi;
+  final s1 = sqrt(1 - u1), s2 = sqrt(u1);
+  return Quaternion(s1 * sin(u2), s1 * cos(u2), s2 * sin(u3), s2 * cos(u3));
+}

--- a/lib/data/physics/physics_cannon_dart.dart
+++ b/lib/data/physics/physics_cannon_dart.dart
@@ -1,0 +1,130 @@
+import 'package:vector_math/vector_math_64.dart';
+import '../../core/utils/random_utils.dart';
+import '../../domain/services/physics_service.dart';
+
+class _Body {
+  Vector3 position;
+  Quaternion rotation;
+  Vector3 velocity;
+  Vector3 angularVelocity;
+  bool sleeping;
+  _Body({required this.position, required this.rotation})
+      : velocity = Vector3.zero(),
+        angularVelocity = Vector3.zero(),
+        sleeping = false;
+}
+
+class CannonDartPhysicsService implements PhysicsService {
+  final Map<String, _Body> _bodies = {};
+  int _id = 0;
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  void addGround({double size = 50}) {}
+
+  @override
+  String addDice({double size = 1.0, double mass = 1.0}) {
+    final id = (++_id).toString();
+    _bodies[id] = _Body(position: Vector3(0, 1, 0), rotation: Quaternion.identity());
+    return id;
+  }
+
+  @override
+  void randomizeDice(String id, {double xBias = 0}) {
+    final b = _bodies[id]!;
+    b.position = Vector3(xBias + rnd(-1, 1), rnd(6, 8), rnd(-1, 1));
+    b.velocity = rndVec(5)..y = 0;
+    b.velocity.y = rnd(3, 8);
+    b.angularVelocity = rndVec(10);
+    b.rotation = rndQuat();
+    b.sleeping = false;
+  }
+
+  static const _g = -9.81;
+  static const _restitution = 0.3;
+  static const _friction = 0.98;
+
+  @override
+  void step(double dt) {
+    for (final b in _bodies.values) {
+      if (b.sleeping) continue;
+      b.velocity.y += _g * dt;
+      b.position += b.velocity * dt;
+      final ang = b.angularVelocity * dt;
+      if (ang.length2 > 0) {
+        final q = Quaternion.axisAngle(ang.normalized(), ang.length);
+        b.rotation = (b.rotation * q).normalized();
+      }
+      if (b.position.y <= 0.5) {
+        b.position.y = 0.5;
+        if (b.velocity.y < 0) b.velocity.y = -b.velocity.y * _restitution;
+        b.velocity.x *= _friction;
+        b.velocity.z *= _friction;
+        if (b.velocity.length < 0.1 && b.angularVelocity.length < 0.1) {
+          b.velocity.setZero();
+          b.angularVelocity.setZero();
+          b.sleeping = true;
+        }
+      }
+    }
+  }
+
+  @override
+  ({Vector3 position, Quaternion rotation, bool sleeping}) stateOf(String id) {
+    final b = _bodies[id]!;
+    return (position: b.position.clone(), rotation: b.rotation.clone(), sleeping: b.sleeping);
+  }
+
+  @override
+  void resetBodies() {
+    for (final b in _bodies.values) {
+      b.position = Vector3(0, 1, 0);
+      b.velocity.setZero();
+      b.angularVelocity.setZero();
+      b.rotation = Quaternion.identity();
+      b.sleeping = true;
+    }
+  }
+
+  @override
+  int topFace(String id) {
+    final b = _bodies[id]!;
+    final faces = {
+      1: Vector3(0, 1, 0),
+      6: Vector3(0, -1, 0),
+      3: Vector3(1, 0, 0),
+      4: Vector3(-1, 0, 0),
+      2: Vector3(0, 0, 1),
+      5: Vector3(0, 0, -1),
+    };
+    double best = -double.infinity;
+    int top = 1;
+    final rot = Matrix3.identity();
+    b.rotation.toRotationMatrix(rot);
+    final up = Vector3(0, 1, 0);
+    faces.forEach((num, normal) {
+      final world = rot.transformed(normal);
+      final d = world.dot(up);
+      if (d > best) {
+        best = d;
+        top = num;
+      }
+    });
+    return top;
+  }
+  void setRotation(String id, Quaternion rot) {
+    final b = _bodies[id];
+    if (b != null) {
+      b.rotation = rot;
+      b.sleeping = true;
+    }
+  }
+
+
+  @override
+  void dispose() {
+    _bodies.clear();
+  }
+}

--- a/lib/data/physics/physics_cannon_js.dart
+++ b/lib/data/physics/physics_cannon_js.dart
@@ -1,0 +1,7 @@
+import 'dart:html';
+import 'package:js/js.dart';
+import '../../domain/services/physics_service.dart';
+import 'physics_cannon_dart.dart';
+
+// Simple placeholder that reuses the Dart implementation.
+class CannonJsPhysicsService extends CannonDartPhysicsService implements PhysicsService {}

--- a/lib/data/render/three_render_service.dart
+++ b/lib/data/render/three_render_service.dart
@@ -1,0 +1,81 @@
+import 'dart:html';
+import 'package:flutter_gl/flutter_gl.dart';
+import 'package:three_dart/three_dart.dart' as three;
+import 'package:vector_math/vector_math_64.dart';
+import '../../domain/services/render_service.dart';
+
+class ThreeRenderService implements RenderService {
+  late FlutterGlPlugin _gl;
+  late three.Scene _scene;
+  late three.PerspectiveCamera _camera;
+  late three.WebGLRenderer _renderer;
+  final Map<String, three.Object3D> _meshes = {};
+  int _id = 0;
+
+  @override
+  Future<void> init({required HtmlElement host}) async {
+    _gl = FlutterGlPlugin();
+    await _gl.initialize(options: {
+      'width': host.clientWidth,
+      'height': host.clientHeight,
+      'canvas': host,
+    });
+    _scene = three.Scene();
+    _camera = three.PerspectiveCamera(
+        55, host.clientWidth / host.clientHeight, 0.1, 1000)
+      ..position.setValues(0, 6, 10);
+    final hemi = three.HemisphereLight(three.Color(0xffffff), three.Color(0x444444), 0.6);
+    _scene.add(hemi);
+    final dir = three.DirectionalLight(three.Color(0xffffff), 0.8)
+      ..position.setValues(5, 10, 7);
+    _scene.add(dir);
+    _renderer = three.WebGLRenderer({'canvas': _gl.element});
+    _renderer.setSize(host.clientWidth, host.clientHeight);
+  }
+
+  @override
+  String addGroundMesh(double size) {
+    final geo = three.PlaneGeometry(size, size);
+    final mat = three.MeshStandardMaterial({'color': 0x888888});
+    final mesh = three.Mesh(geo, mat)..rotation.x = -three.Math.PI / 2;
+    _scene.add(mesh);
+    final id = (++_id).toString();
+    _meshes[id] = mesh;
+    return id;
+  }
+
+  @override
+  String addDiceMesh(double size, {String? textureAsset}) {
+    final geo = three.BoxGeometry(size, size, size);
+    late three.MeshStandardMaterial mat;
+    if (textureAsset != null) {
+      final tex = three.TextureLoader().load(textureAsset);
+      mat = three.MeshStandardMaterial({'map': tex});
+    } else {
+      mat = three.MeshStandardMaterial({'color': 0xffffff});
+    }
+    final mesh = three.Mesh(geo, mat);
+    _scene.add(mesh);
+    final id = (++_id).toString();
+    _meshes[id] = mesh;
+    return id;
+  }
+
+  @override
+  void sync(String meshId, Vector3 pos, Quaternion rot) {
+    final mesh = _meshes[meshId];
+    mesh?.position.setValues(pos.x, pos.y, pos.z);
+    mesh?.quaternion.set(rot.x, rot.y, rot.z, rot.w);
+  }
+
+  @override
+  void renderFrame() {
+    _renderer.render(_scene, _camera);
+  }
+
+  @override
+  void dispose() {
+    _meshes.clear();
+    _gl.dispose();
+  }
+}

--- a/lib/domain/entities/dice.dart
+++ b/lib/domain/entities/dice.dart
@@ -1,0 +1,5 @@
+class Dice {
+  final String bodyId;
+  final String meshId;
+  Dice({required this.bodyId, required this.meshId});
+}

--- a/lib/domain/entities/roll_result.dart
+++ b/lib/domain/entities/roll_result.dart
@@ -1,0 +1,6 @@
+class RollResult {
+  final int left;
+  final int right;
+  int get sum => left + right;
+  const RollResult(this.left, this.right);
+}

--- a/lib/domain/services/physics_service.dart
+++ b/lib/domain/services/physics_service.dart
@@ -1,0 +1,13 @@
+import 'package:vector_math/vector_math_64.dart';
+
+abstract class PhysicsService {
+  Future<void> init();
+  void addGround({double size = 50});
+  String addDice({double size = 1.0, double mass = 1.0});
+  void randomizeDice(String id, {double xBias = 0});
+  void step(double dt);
+  ({Vector3 position, Quaternion rotation, bool sleeping}) stateOf(String id);
+  void resetBodies();
+  int topFace(String id);
+  void dispose();
+}

--- a/lib/domain/services/render_service.dart
+++ b/lib/domain/services/render_service.dart
@@ -1,0 +1,11 @@
+import 'dart:html';
+import 'package:vector_math/vector_math_64.dart';
+
+abstract class RenderService {
+  Future<void> init({required HtmlElement host});
+  String addGroundMesh(double size);
+  String addDiceMesh(double size, {String? textureAsset});
+  void sync(String meshId, Vector3 pos, Quaternion rot);
+  void renderFrame();
+  void dispose();
+}

--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+import 'pages/home_page.dart';
+
+class App extends StatelessWidget {
+  const App({super.key});
+  @override
+  Widget build(BuildContext context) =>
+      const MaterialApp(debugShowCheckedModeBanner: false, home: HomePage());
+}

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'dart:html' as html;
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../viewmodels/dice_view_model.dart';
+import '../widgets/overlay_controls.dart';
+import '../widgets/fps_badge.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  late Timer _timer;
+  html.DivElement? _host;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(milliseconds: 16), (_) {
+      context.read<DiceViewModel>().update(1 / 60);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<DiceViewModel>();
+    return Scaffold(
+      body: Stack(children: [
+        HtmlElementView(
+          viewType: 'three-canvas',
+          onPlatformViewCreated: (_) async {
+            _host ??= html.DivElement()
+              ..style.width = '100%'
+              ..style.height = '100%';
+            await vm.init(_host!);
+          },
+        ),
+        Positioned(
+          left: 16,
+          top: 16,
+          child: OverlayControls(
+            onRoll: vm.running ? null : vm.roll,
+            onReset: vm.reset,
+            resultLeft: vm.result1,
+            resultRight: vm.result2,
+          ),
+        ),
+        Positioned(right: 16, top: 16, child: FpsBadge(fps: vm.fps.fps)),
+      ]),
+    );
+  }
+}

--- a/lib/ui/widgets/fps_badge.dart
+++ b/lib/ui/widgets/fps_badge.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class FpsBadge extends StatelessWidget {
+  final double fps;
+  const FpsBadge({super.key, required this.fps});
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+            color: Colors.black54, borderRadius: BorderRadius.circular(12)),
+        child: Text('${fps.toStringAsFixed(0)} FPS',
+            style: const TextStyle(color: Colors.white)),
+      );
+}

--- a/lib/ui/widgets/overlay_controls.dart
+++ b/lib/ui/widgets/overlay_controls.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class OverlayControls extends StatelessWidget {
+  final VoidCallback? onRoll;
+  final VoidCallback onReset;
+  final int? resultLeft;
+  final int? resultRight;
+  const OverlayControls({super.key, this.onRoll, required this.onReset, this.resultLeft, this.resultRight});
+
+  @override
+  Widget build(BuildContext context) {
+    final sum = (resultLeft != null && resultRight != null) ? (resultLeft! + resultRight!) : null;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          Row(children: [
+            ElevatedButton(onPressed: onRoll, child: const Text('Roll')),
+            const SizedBox(width: 8),
+            OutlinedButton(onPressed: onReset, child: const Text('Reset')),
+          ]),
+          const SizedBox(height: 8),
+          Text(sum != null ? 'Ergebnis: $resultLeft + $resultRight = $sum' : 'Würfeln…'),
+        ]),
+      ),
+    );
+  }
+}

--- a/lib/viewmodels/dice_view_model.dart
+++ b/lib/viewmodels/dice_view_model.dart
@@ -1,0 +1,67 @@
+import 'dart:html' as html;
+import 'package:flutter/foundation.dart';
+import 'package:vector_math/vector_math_64.dart';
+import '../domain/services/physics_service.dart';
+import '../domain/services/render_service.dart';
+import '../core/utils/fps_counter.dart';
+
+class DiceViewModel extends ChangeNotifier {
+  final PhysicsService physics;
+  final RenderService render;
+  late String dice1Body, dice2Body;
+  late String dice1Mesh, dice2Mesh;
+  bool ready = false;
+  bool running = false;
+  int? result1, result2;
+  final fps = FpsCounter();
+
+  DiceViewModel({required this.physics, required this.render});
+
+  Future<void> init(html.Element host) async {
+    await render.init(host: host as html.HtmlElement);
+    await physics.init();
+    physics.addGround(size: 50);
+    render.addGroundMesh(50);
+    dice1Mesh = render.addDiceMesh(1.0, textureAsset: 'assets/textures/dice_uv.png');
+    dice2Mesh = render.addDiceMesh(1.0, textureAsset: 'assets/textures/dice_uv.png');
+    dice1Body = physics.addDice(size: 1.0, mass: 1.0);
+    dice2Body = physics.addDice(size: 1.0, mass: 1.0);
+    roll();
+    ready = true;
+    notifyListeners();
+  }
+
+  void roll() {
+    result1 = null;
+    result2 = null;
+    physics.randomizeDice(dice1Body, xBias: -1.2);
+    physics.randomizeDice(dice2Body, xBias: 1.2);
+    running = true;
+    notifyListeners();
+  }
+
+  void reset() {
+    physics.resetBodies();
+    result1 = null;
+    result2 = null;
+    running = false;
+    notifyListeners();
+  }
+
+  void update(double dt) {
+    if (!ready) return;
+    physics.step(dt);
+    final s1 = physics.stateOf(dice1Body);
+    final s2 = physics.stateOf(dice2Body);
+    render.sync(dice1Mesh, s1.position, s1.rotation);
+    render.sync(dice2Mesh, s2.position, s2.rotation);
+    render.renderFrame();
+    fps.tick(dt);
+    if (running && s1.sleeping && s2.sleeping) {
+      result1 = physics.topFace(dice1Body);
+      result2 = physics.topFace(dice2Body);
+      running = false;
+      notifyListeners();
+    }
+  }
+}

--- a/main.dart
+++ b/main.dart
@@ -1,0 +1,22 @@
+import 'dart:html';
+import 'dart:ui_web' as ui;
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'ui/app.dart';
+import 'viewmodels/dice_view_model.dart';
+import 'core/di/locator.dart';
+
+void main() {
+  ui.platformViewRegistry.registerViewFactory('three-canvas', (int viewId) {
+    final div = DivElement()
+      ..style.width = '100%'
+      ..style.height = '100%';
+    return div;
+  });
+
+  runApp(MultiProvider(providers: [
+    ChangeNotifierProvider(
+        create: (_) => DiceViewModel(
+            physics: Locator.physics(), render: Locator.render())),
+  ], child: const App()));
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,24 @@
+name: flutter_dice_3d
+description: 3D Dice (Flutter Web) mit MVVM, Three + Physik
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_gl: ^0.0.22
+  three_dart: ^0.0.1
+  vector_math: ^2.1.4
+  cannon_physics: ^0.1.0
+  js: ^0.6.7
+  web: ^0.5.1
+  provider: ^6.1.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/textures/dice_uv.png

--- a/test/top_face_test.dart
+++ b/test/top_face_test.dart
@@ -1,0 +1,17 @@
+import 'dart:math';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+import 'package:flutter_dice_3d/data/physics/physics_cannon_dart.dart';
+
+void main() {
+  test('topFace detects correct face', () async {
+    final phys = CannonDartPhysicsService();
+    await phys.init();
+    final id = phys.addDice();
+    expect(phys.topFace(id), 1);
+    phys.setRotation(id, Quaternion.axisAngle(Vector3(1, 0, 0), pi));
+    expect(phys.topFace(id), 6);
+    phys.setRotation(id, Quaternion.axisAngle(Vector3(0, 0, 1), -pi / 2));
+    expect(phys.topFace(id), 3);
+  });
+}

--- a/test/view_model_test.dart
+++ b/test/view_model_test.dart
@@ -1,0 +1,67 @@
+import 'dart:html';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dice_3d/viewmodels/dice_view_model.dart';
+import 'package:flutter_dice_3d/domain/services/physics_service.dart';
+import 'package:flutter_dice_3d/domain/services/render_service.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+class FakeRenderService implements RenderService {
+  @override
+  Future<void> init({required HtmlElement host}) async {}
+  @override
+  String addGroundMesh(double size) => 'g';
+  @override
+  String addDiceMesh(double size, {String? textureAsset}) => 'm$size';
+  @override
+  void sync(String meshId, Vector3 pos, Quaternion rot) {}
+  @override
+  void renderFrame() {}
+  @override
+  void dispose() {}
+}
+
+class StubPhysicsService implements PhysicsService {
+  final Map<String, bool> _sleep = {};
+  int _id = 0;
+  @override
+  Future<void> init() async {}
+  @override
+  void addGround({double size = 50}) {}
+  @override
+  String addDice({double size = 1.0, double mass = 1.0}) {
+    final id = (++_id).toString();
+    _sleep[id] = false;
+    return id;
+  }
+  @override
+  void randomizeDice(String id, {double xBias = 0}) {
+    _sleep[id] = false;
+  }
+  @override
+  void step(double dt) {
+    _sleep.updateAll((key, value) => true);
+  }
+  @override
+  ({Vector3 position, Quaternion rotation, bool sleeping}) stateOf(String id) =>
+      (position: Vector3.zero(), rotation: Quaternion.identity(), sleeping: _sleep[id] ?? true);
+  @override
+  void resetBodies() {
+    _sleep.updateAll((key, value) => true);
+  }
+  @override
+  int topFace(String id) => 1;
+  @override
+  void dispose() {}
+}
+
+void main() {
+  test('viewmodel update stops when dice sleep', () async {
+    final vm = DiceViewModel(physics: StubPhysicsService(), render: FakeRenderService());
+    await vm.init(DivElement());
+    expect(vm.running, true);
+    vm.update(0.016);
+    expect(vm.running, false);
+    expect(vm.result1, isNotNull);
+    expect(vm.result2, isNotNull);
+  });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+  <title>Flutter Dice 3D</title>
+  <script type="module" src="https://cdn.skypack.dev/cannon-es"></script>
+  <style>
+    html, body { margin:0; height:100%; overflow:hidden; }
+    #flutter_canvas { width:100%; height:100%; }
+  </style>
+</head>
+<body>
+  <script src="main.dart.js" type="application/javascript"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold Flutter Web dice roller with MVVM
- implement stub physics and rendering services
- add basic tests for dice top-face and viewmodel flow
- remove placeholder dice texture so users can provide their own

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88f7fd86c8325a816dde6a974b787